### PR TITLE
fix: exports `scanText` function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import { useRunInJS } from 'react-native-worklets-core';
 import { scanText } from './scanText';
 import type { CameraTypes, Frame, FrameProcessor } from './types';
 
+export { scanText } from './scanText';
+
 export const Camera = forwardRef(function Camera(props: CameraTypes,ref:ForwardedRef<any>) {
   const { callback, device, options } = props;
   // @ts-ignore


### PR DESCRIPTION
Exports the `scanText` function in `src/index.tsx`
so the plugin can be implemented in a custom `Camera` or `frameProcessor` implementation